### PR TITLE
docs(changelog): Add change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,50 @@
+<a name="0.0.8"></a>
+## 0.0.8 (2017-01-30)
+
+* chore(package.json): Release 0.0.8 (#15) ([0b0fa9e](https://github.com/stryker-mutator/stryker-cli/commit/0b0fa9e))
+* chore(stryker-cli.ts): Improve reabability (#11) ([d5aaeb7](https://github.com/stryker-mutator/stryker-cli/commit/d5aaeb7))
+* docs(README.md): Add global install preference (#13) ([807c052](https://github.com/stryker-mutator/stryker-cli/commit/807c052))
+* docs(README.md): Make link to Stryker https (#16) ([b5aea7c](https://github.com/stryker-mutator/stryker-cli/commit/b5aea7c))
+
+
+
 <a name="0.0.7"></a>
-## [0.0.7](https://github.com/stryker-mutator/stryker-cli/compare/v0.0.6...v0.0.7) (2017-01-29)
+## 0.0.7 (2017-01-29)
+
+* chore: release v0.0.7 ([20b3123](https://github.com/stryker-mutator/stryker-cli/commit/20b3123))
 
 
 
 <a name="0.0.6"></a>
 ## 0.0.6 (2017-01-29)
 
+* chore: add LICENSE file ([4149ced](https://github.com/stryker-mutator/stryker-cli/commit/4149ced))
+* chore: release v0.0.6 ([d97094e](https://github.com/stryker-mutator/stryker-cli/commit/d97094e))
+* chore: update contributors ([7751165](https://github.com/stryker-mutator/stryker-cli/commit/7751165))
+* chore: update contributors ([f2f552e](https://github.com/stryker-mutator/stryker-cli/commit/f2f552e))
+* chore: Update to stryker-api@0.3.0-rc2 ([5dcab0c](https://github.com/stryker-mutator/stryker-cli/commit/5dcab0c))
+* chore(*): Cleanup repository (#2) ([16fc94c](https://github.com/stryker-mutator/stryker-cli/commit/16fc94c))
+* chore(index): Delete index.ts ([b8529ef](https://github.com/stryker-mutator/stryker-cli/commit/b8529ef))
+* chore(package.json): Preparing release ([7f058c3](https://github.com/stryker-mutator/stryker-cli/commit/7f058c3))
+* chore(package): Add bin entry to package ([926c472](https://github.com/stryker-mutator/stryker-cli/commit/926c472))
+* chore(package): prefer global installation ([4b809d0](https://github.com/stryker-mutator/stryker-cli/commit/4b809d0))
+* chore(package): Update version ([7999082](https://github.com/stryker-mutator/stryker-cli/commit/7999082))
+* fix(stryker-cli.ts): Only show logo when installing \n\n Add CHANGELOG.md for grunt release. ASCII L ([0768449](https://github.com/stryker-mutator/stryker-cli/commit/0768449))
+* docs(contributing): Add CONTRIBUTING.md ([a6ec885](https://github.com/stryker-mutator/stryker-cli/commit/a6ec885))
+* docs(README.md): Add info on installing Stryker (#12) ([d74a452](https://github.com/stryker-mutator/stryker-cli/commit/d74a452))
+* docs(README.md): add install cli using npm ([31aede9](https://github.com/stryker-mutator/stryker-cli/commit/31aede9))
+* docs(README.md): change README to fit cli project ([9f8953c](https://github.com/stryker-mutator/stryker-cli/commit/9f8953c))
+* docs(README.md): Fix cli naming issue (#6) ([680730c](https://github.com/stryker-mutator/stryker-cli/commit/680730c)), closes [#6](https://github.com/stryker-mutator/stryker-cli/issues/6)
+* docs(seed): Fix a few minor spelling mistakes ([17813ec](https://github.com/stryker-mutator/stryker-cli/commit/17813ec))
+* Find stryker bin (#5) ([0ac5e8d](https://github.com/stryker-mutator/stryker-cli/commit/0ac5e8d))
+* Fix(.gitattributes) Fix eol problem ([d4d1ade](https://github.com/stryker-mutator/stryker-cli/commit/d4d1ade))
+* fix(MyTestRunner) Use RunStatus and TestStatus ([e78c92a](https://github.com/stryker-mutator/stryker-cli/commit/e78c92a))
+* feat: Stryker ASCII Art ([c98da96](https://github.com/stryker-mutator/stryker-cli/commit/c98da96))
+* feat: Update package.json (#3) ([44caebd](https://github.com/stryker-mutator/stryker-cli/commit/44caebd))
+* feat(es2015-promise): Remove dep to es6-promise (#4) ([3faa3e4](https://github.com/stryker-mutator/stryker-cli/commit/3faa3e4))
+* feat(index.ts): Find Stryker bin and send command (#4) ([a3bd328](https://github.com/stryker-mutator/stryker-cli/commit/a3bd328))
+* feat(index.ts): Prompt install ([a467a88](https://github.com/stryker-mutator/stryker-cli/commit/a467a88))
+* feat(seed): Initial commit ([5633910](https://github.com/stryker-mutator/stryker-cli/commit/5633910))
 
-### Bug Fixes
-
-* **stryker-cli.ts:** Only show logo when installing \n\n Add CHANGELOG.md for grunt release. ASCII Logo only shows when first time installing ([0768449](https://github.com/stryker-mutator/stryker-cli/commit/0768449))
 
 
-### Features
-
-* **es2015-promise:** Remove dep to es6-promise ([#4](https://github.com/stryker-mutator/stryker-cli/issues/4)) ([3faa3e4](https://github.com/stryker-mutator/stryker-cli/commit/3faa3e4))
-* **index.ts:** Find Stryker bin and send command ([#4](https://github.com/stryker-mutator/stryker-cli/issues/4)) ([a3bd328](https://github.com/stryker-mutator/stryker-cli/commit/a3bd328))
-* **index.ts:** Prompt install ([a467a88](https://github.com/stryker-mutator/stryker-cli/commit/a467a88))
-* **seed:** Initial commit ([5633910](https://github.com/stryker-mutator/stryker-cli/commit/5633910))
-* Stryker ASCII Art ([c98da96](https://github.com/stryker-mutator/stryker-cli/commit/c98da96))
-* Update package.json ([#3](https://github.com/stryker-mutator/stryker-cli/issues/3)) ([44caebd](https://github.com/stryker-mutator/stryker-cli/commit/44caebd))
-
-
-
-# Todo


### PR DESCRIPTION
With this changelog in place, it will be posible to use `grunt release` to release a new (patch) version of your api. You can use `grunt release:minor` for example to release a minor release.