### PR TITLE
fix(asciiart): Make S in logo yellow in Powershell

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/stryker-mutator/stryker-cli#readme",
   "dependencies": {
-    "chalk": "^1.1.1",
+    "chalk": "^1.1.3",
     "inquirer": "^3.0.1",
     "resolve": "^1.3.3"
   },


### PR DESCRIPTION
This tries to fix #19. 

The problem is a more general issue with Powershell's ability to deal with ANSI Codes. We use `chalk` to display colours and luckily they've been working on this problem too (see [this](https://github.com/chalk/chalk/issues/98) and [this](https://github.com/chalk/chalk/issues/76)). 

I hope that updating `chalk` to a newer version (1.1.1 -> 1.1.3) will solve the problem, but I have no way of testing it.  @simondel Can you please verify whether this solves the problem?
