### PR TITLE
fix(stryker-cli): support missing installation errors on newer npm versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stryker-cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/stryker-cli.ts
+++ b/src/stryker-cli.ts
@@ -14,7 +14,7 @@ export function run(): Promise<void> {
   try {
     return runLocalStryker();
   } catch (error) {
-    if (error.toString().indexOf(`Cannot find module '@stryker-mutator/core'`) >= 0) {
+    if (error.toString().indexOf(`Cannot find module '@stryker-mutator/core`) >= 0) {
       return promptInstallStryker().then(packageManager => {
         if (packageManager !== undefined) {
           installStryker(installCommands[packageManager]);


### PR DESCRIPTION
Fixes #48 