### PR TITLE
chore(readme): deprecate package warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ This is the command-line interface (CLI) for [Stryker](https://stryker-mutator.g
 
 If you plan on using Stryker in more projects, the Stryker-CLI is the easiest way to install, configure and run Stryker for your project.
 
+> [!WARNING]
+> Deprecation Warning: `stryker-cli` is deprecated and will no longer receive updates or support.
+
+Instead running and installing stryker can now be achieved fully through `stryker-js`.
+
+For guidance and documentation, visit: https://stryker-mutator.io/docs/stryker-js/getting-started/
+
+
 # Installation
 The Stryker-CLI can be easily installed using NPM.
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Instead running and installing Stryker can now be achieved fully through [stryke
 
 For guidance and documentation, visit: https://stryker-mutator.io/docs/stryker-js/getting-started/
 
-<br><br><br><br><br><br><br><br><br><br><br><br>
-<br><br><br><br><br><br><br><br><br><br><br><br>
+<br><br><br><br><br><br><br><br>
 
 
 [![Build Status](https://travis-ci.org/stryker-mutator/stryker-cli.svg?branch=master)](https://travis-ci.org/stryker-mutator/stryker-cli)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+> [!CAUTION]
+> Deprecation Warning: `stryker-cli` is deprecated and will no longer receive updates or support.
+
+Instead running and installing Stryker can now be achieved fully through [stryker-js](https://github.com/stryker-mutator/stryker-js).
+
+For guidance and documentation, visit: https://stryker-mutator.io/docs/stryker-js/getting-started/
+
+<br><br><br><br><br><br><br><br><br><br><br><br>
+<br><br><br><br><br><br><br><br><br><br><br><br>
+
+
 [![Build Status](https://travis-ci.org/stryker-mutator/stryker-cli.svg?branch=master)](https://travis-ci.org/stryker-mutator/stryker-cli)
 [![Gitter](https://badges.gitter.im/stryker-mutator/stryker.svg)](https://gitter.im/stryker-mutator/stryker?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
@@ -7,13 +18,6 @@
 This is the command-line interface (CLI) for [Stryker](https://stryker-mutator.github.io), the JavaScript mutation testing framework.
 
 If you plan on using Stryker in more projects, the Stryker-CLI is the easiest way to install, configure and run Stryker for your project.
-
-> [!WARNING]
-> Deprecation Warning: `stryker-cli` is deprecated and will no longer receive updates or support.
-
-Instead running and installing stryker can now be achieved fully through `stryker-js`.
-
-For guidance and documentation, visit: https://stryker-mutator.io/docs/stryker-js/getting-started/
 
 
 # Installation


### PR DESCRIPTION
This fixes #33, as the package will be deprecated at the same time through npm itself.

Readme preview:
<img width="1209" height="811" alt="image" src="https://github.com/user-attachments/assets/10bf3e5c-79ea-4355-b12b-b320ca76b79e" />
